### PR TITLE
Fix expected return type of `get_daily_price_series`

### DIFF
--- a/NorenRestApiPy/NorenApi.py
+++ b/NorenRestApiPy/NorenApi.py
@@ -679,7 +679,7 @@ class NorenApi:
                   "to": str(enddate)}
 
         headers = {"Content-Type": "application/json; charset=utf-8"}
-        return self.send_payload(url, values, headers=headers)
+        return self.send_payload(url, values, headers=headers, expected_return_type="list")
 
     def get_holdings(self, product_type=None):
         config = NorenApi.__service_config


### PR DESCRIPTION
`get_daily_price_series` returns a list, hence requires the parameter `expected_return_type="list"` while calling `send_payload`